### PR TITLE
Fix "No such file or directory" error

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -10,13 +10,14 @@
 # ---------------------------------------------------------------------------------------
 
 # This bash script must be run into downloaded Boston Icons directory. Open a terminal on it.
-# To give permissions: chmod +x ./install.sh
 # Run with: ./install.sh
 # Double click can run it without command prompt, but this method doesn't show any message.
 
+set -e
+
 # --------------------------------------DEFINITIONS--------------------------------------
 
-ver=0.1
+ver=0.1.1
 
 redback='\033[1;101m' #Red background
 green='\033[1;32m' #Green font

--- a/install.sh
+++ b/install.sh
@@ -65,18 +65,28 @@ title
 
 echo " Hi, $USER"
 
-if [ ${PWD##*/} != "Boston" ]; then
-  notFound
-  exit 1
-fi
+#if [ ${PWD##*/} != "Boston" ]; then
+#  notFound
+#  exit 1
+#fi
 
 if [ $DESKTOP_SESSION != "gnome" ]; then
   noGNOME
 fi
 
-mkdir -p ~/.icons/Boston/
-rm -r ~/.icons/Boston/*
-cp -r * ~/.icons/Boston/
+boston_dir="$HOME/.icons/Boston"
+mkdir -p "${boston_dir}"
+
+# Remove contents of output directory, if any
+shopt -s nullglob dotglob  # Set to include hidden files
+files=$(echo "${boston_dir}"/*)
+if (( ${#files} )); then
+  rm -r "${boston_dir}"/*
+fi
+shopt -u nullglob dotglob  # Unset to go back to normal
+
+# Copy theme to output folder
+cp -r * "${boston_dir}"
 
 gsettings set org.gnome.desktop.interface icon-theme 'Boston'
 

--- a/install.sh
+++ b/install.sh
@@ -65,10 +65,10 @@ title
 
 echo " Hi, $USER"
 
-#if [ ${PWD##*/} != "Boston" ]; then
-#  notFound
-#  exit 1
-#fi
+if [ ${PWD##*/} != "Boston" ]; then
+  notFound
+  exit 1
+fi
 
 if [ $DESKTOP_SESSION != "gnome" ]; then
   noGNOME


### PR DESCRIPTION
When installing into a clean environment (no `~/.icons/Boston` or empty directory), calling `rm -rf ~/.icon/Boston/*` would result in an error:

```
rm: cannot remove '/home/simon/.icons/Boston/*': No such file or directory
```

To prevent this, I implemented a check againt any files actually being present in that directory.